### PR TITLE
feat: show modules only command

### DIFF
--- a/src/background/app.ts
+++ b/src/background/app.ts
@@ -34,7 +34,13 @@ const onAngularToggle = () => {
   setConfigProps({ showLibs });
 };
 
-const menuItems = [applicationMenuTemplate(onThemeChange, onAngularToggle)];
+const onModulesToggle = () => {
+  const config = getConfig();
+  const showModules = !config.showModules;
+  setConfigProps({ showModules });
+};
+
+const menuItems = [applicationMenuTemplate(onThemeChange, onAngularToggle, onModulesToggle)];
 if (env.name !== 'production') {
   menuItems.push(devMenuTemplate());
 }

--- a/src/background/config.ts
+++ b/src/background/config.ts
@@ -22,7 +22,7 @@ export const getConfig = () => {
     console.log('Found config file');
   } catch (_) {
     console.log('Config file not found');
-    return { showLibs: false, theme: DefaultTheme, themes: builtInThemesMap } as Partial<Config>;
+    return { showLibs: false, showModules: false, theme: DefaultTheme, themes: builtInThemesMap } as Partial<Config>;
   }
   try {
     themes = readdirSync(join(path, 'themes'))
@@ -31,12 +31,13 @@ export const getConfig = () => {
     console.log('Found themes');
   } catch (_) {
     console.log('Themes not found', _);
-    return { showLibs: !!(config as any).showLibs, theme: (config as any).theme, themes: builtInThemesMap } as Partial<
+    return { showLibs: !!(config as any).showLibs, showModules: !!(config as any).showModules, theme: (config as any).theme, themes: builtInThemesMap } as Partial<
       Config
     >;
   }
   return {
     showLibs: !!(config as any).showLibs,
+    showModules: !!(config as any).showModules,
     theme: (config as any).theme,
     themes: Object.assign(
       themes.reduce((a, t) => {

--- a/src/background/helpers/process.ts
+++ b/src/background/helpers/process.ts
@@ -10,6 +10,7 @@ export interface IdentifiedStaticSymbol extends StaticSymbol {
 
 export interface LoadProjectRequest {
   showLibs: boolean;
+  showModules: boolean;
   topic: Message.LoadProject;
   tsconfig: string;
 }
@@ -83,6 +84,15 @@ export interface ToggleLibsRequest {
   topic: Message.ToggleLibs;
 }
 
+export interface ToggleModulesResponse {
+  topic: Message.ToggleModules;
+}
+
+export interface ToggleModulesRequest {
+  topic: Message.ToggleModules;
+}
+
+
 export type IPCRequest =
   | LoadProjectRequest
   | PrevStateRequest
@@ -91,7 +101,8 @@ export type IPCRequest =
   | GetMetadataRequest
   | GetDataRequest
   | ConfigRequest
-  | ToggleLibsRequest;
+  | ToggleLibsRequest
+  | ToggleModulesRequest;
 
 export type IPCResponse =
   | LoadProjectResponse
@@ -101,7 +112,8 @@ export type IPCResponse =
   | GetMetadataResponse
   | GetDataResponse
   | ConfigResponse
-  | ToggleLibsResponse;
+  | ToggleLibsResponse
+  | ToggleModulesResponse;
 
 export interface Responder {
   (data: IPCResponse): void;

--- a/src/background/menu/application_menu_template.ts
+++ b/src/background/menu/application_menu_template.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import { Message } from '../../shared/ipc-constants';
 import { getConfig } from '../config';
 
-export const applicationMenuTemplate = (onThemeChange: (name: string) => void, onLibraryToggle: () => void) => {
+export const applicationMenuTemplate = (onThemeChange: (name: string) => void, onLibraryToggle: () => void, onModulesToggle: () => void) => {
   return {
     label: 'ngrev',
     submenu: [
@@ -35,6 +35,15 @@ export const applicationMenuTemplate = (onThemeChange: (name: string) => void, o
           const window = BrowserWindow.getAllWindows()[0];
           onLibraryToggle();
           window.webContents.send(Message.ToggleLibsMenuAction);
+        }
+      },
+      {
+        label: 'Show modules only',
+        accelerator: 'CmdOrCtrl+M',
+        click() {
+          const window = BrowserWindow.getAllWindows()[0];
+          onModulesToggle();
+          window.webContents.send(Message.ToggleModulesMenuAction);
         }
       },
       {

--- a/src/background/model/background-app.ts
+++ b/src/background/model/background-app.ts
@@ -58,7 +58,7 @@ export class BackgroundApp {
       success(e.sender, Message.Config, config);
     });
 
-    ipcMain.on(Message.LoadProject, (e, { tsconfig, showLibs }: { tsconfig: string; showLibs: boolean }) => {
+    ipcMain.on(Message.LoadProject, (e, { tsconfig, showLibs, showModules }: { tsconfig: string; showLibs: boolean; showModules: boolean }) => {
       if (!this.slaveProcess.connected) {
         console.log('The slave process is not ready yet');
       } else {
@@ -70,7 +70,8 @@ export class BackgroundApp {
           .send({
             topic: Message.LoadProject,
             tsconfig,
-            showLibs
+            showLibs,
+            showModules
           })
           .then((data: LoadProjectResponse) => {
             if (data.err) {
@@ -184,6 +185,20 @@ export class BackgroundApp {
           .then(() => {
             console.log('The slave process toggled the libs');
             success(e.sender, Message.ToggleLibs, true);
+          });
+      });
+    });
+
+    ipcMain.on(Message.ToggleModules, e => {
+      console.log('Toggle modules!');
+      this.taskQueue.push(() => {
+        return this.slaveProcess
+          .send({
+            topic: Message.ToggleModules
+          })
+          .then(() => {
+            console.log('The slave process toggled the modules');
+            success(e.sender, Message.ToggleModules, true);
           });
       });
     });

--- a/src/background/parser.ts
+++ b/src/background/parser.ts
@@ -43,7 +43,7 @@ export class BackgroundApp {
             .pop();
           if (module) {
             console.log('Project loaded');
-            this.states.push(new AppState(this.project.projectSymbols, data.showLibs));
+            this.states.push(new AppState(this.project.projectSymbols, data.showLibs, data.showModules));
             console.log('Initial state created');
             responder({
               topic: Message.LoadProject,
@@ -187,10 +187,20 @@ export class BackgroundApp {
     this.parentProcess.on(Message.ToggleLibs, (_: any, responder: Responder) => {
       console.log('Toggle libraries');
       const state = this.states.shift() as AppState;
-      const newState = new AppState(this.project.projectSymbols, !state.showLibs);
+      const newState = new AppState(this.project.projectSymbols, !state.showLibs, !state.showModules);
       this.states.unshift(newState);
       responder({
         topic: Message.ToggleLibs
+      });
+    });
+
+    this.parentProcess.on(Message.ToggleModules, (_: any, responder: Responder) => {
+      console.log('Toggle modules');
+      const state = this.states.shift() as AppState;
+      const newState = new AppState(this.project.projectSymbols, state.showLibs, !state.showModules);
+      this.states.unshift(newState);
+      responder({
+        topic: Message.ToggleModules
       });
     });
   }

--- a/src/background/states/app.state.ts
+++ b/src/background/states/app.state.ts
@@ -13,13 +13,17 @@ const Title = 'Application View';
 export class AppState extends State {
   private states: State[] = [];
 
-  constructor(context: ProjectSymbols, private _showLibs: boolean) {
+  constructor(context: ProjectSymbols, private _showLibs: boolean, private _showModules: boolean) {
     super(CompositeStateID, context);
     this.init();
   }
 
   get showLibs() {
     return this._showLibs;
+  }
+
+  get showModules() {
+    return this._showModules;
   }
 
   getMetadata(id: string): Metadata | null {
@@ -74,17 +78,19 @@ export class AppState extends State {
     this.context.getModules().forEach(m => {
       this.states.push(new ModuleTreeState(this.context, m));
     });
-    this.context.getModules().forEach(m => {
-      this.states.push(new AppModuleState(this.context, m));
-    });
-    this.context.getDirectives().forEach(d => {
-      this.states.push(new DirectiveState(this.context, d, false));
-    });
-    this.context.getProviders().forEach(p => {
-      this.states.push(new ProviderState(this.context, p));
-    });
-    this.context.getPipes().forEach(p => {
-      this.states.push(new PipeState(this.context, p));
-    });
+    if (!this.showModules) {
+      this.context.getModules().forEach(m => {
+        this.states.push(new AppModuleState(this.context, m));
+      });
+      this.context.getDirectives().forEach(d => {
+        this.states.push(new DirectiveState(this.context, d, false));
+      });
+      this.context.getProviders().forEach(p => {
+        this.states.push(new ProviderState(this.context, p));
+      });
+      this.context.getPipes().forEach(p => {
+        this.states.push(new PipeState(this.context, p));
+      });
+    }
   }
 }

--- a/src/shared/data-format.ts
+++ b/src/shared/data-format.ts
@@ -54,6 +54,7 @@ export enum Layout {
 
 export interface Config {
   showLibs: boolean;
+  showModules: boolean;
   theme: string;
   themes: { [key: string]: Theme };
 }

--- a/src/shared/ipc-constants.ts
+++ b/src/shared/ipc-constants.ts
@@ -1,6 +1,8 @@
 export enum Message {
   ToggleLibsMenuAction = 'toggle-libs-menu-action',
   ToggleLibs = 'toggle-libs',
+  ToggleModulesMenuAction = 'toggle-modules-menu-action',
+  ToggleModules = 'toggle-modules',
   LoadProject = 'load-project',
   PrevState = 'prev-state',
   GetMetadata = 'get-metadata',

--- a/src/ui/components/app.component.ts
+++ b/src/ui/components/app.component.ts
@@ -103,6 +103,7 @@ export class AppComponent {
   theme: Theme;
   themes: { [name: string]: Theme };
   showLibs: boolean;
+  showModules: boolean;
 
   @ViewChild(QuickAccessComponent)
   quickAccess: QuickAccessComponent;
@@ -146,6 +147,12 @@ export class AppComponent {
         this.cd.detectChanges();
       });
     });
+    this.ipcBus.on(Message.ToggleModulesMenuAction, (_: any) => {
+      this.manager.toggleModules().then(() => {
+        this.manager.reloadAppState();
+        this.cd.detectChanges();
+      });
+    });
   }
 
   onWindowResize(e: any) {
@@ -157,6 +164,7 @@ export class AppComponent {
     this.themes = config.themes;
     this.theme = config.themes[config.theme];
     this.showLibs = config.showLibs;
+    this.showModules = config.showModules;
 
     this.cd.detach();
 
@@ -164,7 +172,7 @@ export class AppComponent {
     this.ngZone.run(() => {
       this._startLoading();
       this.manager
-        .loadProject(tsconfig, this.showLibs)
+        .loadProject(tsconfig, this.showLibs, this.showModules)
         .then(() => this.project.getSymbols())
         .then(symbols => (this.queryList = symbols.map(s => ({ key: s.name, value: s }))))
         .then(this._stopLoading)

--- a/src/ui/model/project-proxy.ts
+++ b/src/ui/model/project-proxy.ts
@@ -6,8 +6,8 @@ import { Injectable } from '@angular/core';
 export class ProjectProxy {
   constructor(private ipcBus: IPCBus) {}
 
-  load(tsconfig: string, showLibs: boolean) {
-    return this.ipcBus.send(Message.LoadProject, { tsconfig, showLibs });
+  load(tsconfig: string, showLibs: boolean, showModules: boolean) {
+    return this.ipcBus.send(Message.LoadProject, { tsconfig, showLibs, showModules });
   }
 
   getSymbols() {

--- a/src/ui/model/state-manager.ts
+++ b/src/ui/model/state-manager.ts
@@ -21,9 +21,9 @@ export class StateManager {
     return this.history;
   }
 
-  loadProject(tsconfig: string, showLibs: boolean) {
+  loadProject(tsconfig: string, showLibs: boolean, showModules: boolean) {
     return this.project
-      .load(tsconfig, showLibs)
+      .load(tsconfig, showLibs, showModules)
       .then(() => (this.state = new StateProxy()))
       .then((proxy: StateProxy) => proxy.getData())
       .then(data => this.history.push(new Memento(data)));
@@ -31,6 +31,10 @@ export class StateManager {
 
   toggleLibs() {
     return this.bus.send(Message.ToggleLibs);
+  }
+
+  toggleModules() {
+    return this.bus.send(Message.ToggleModules);
   }
 
   tryChangeState(id: string) {


### PR DESCRIPTION
Hi @mgechev 
For a professional audit, i need to display only modules of the application i am auditing.
This PR contains a new command in the menu that display only the modules of the current view.
Here is an example with real-world-angular-app

Without

![Capture-20190527161530-1888x1053](https://user-images.githubusercontent.com/2841805/58426092-deeef800-809b-11e9-94a7-ac979c0a5a16.png)

And with the option

![Capture-20190527161539-1888x1053](https://user-images.githubusercontent.com/2841805/58426108-e7dfc980-809b-11e9-95c2-4a7869261222.png)

Feel free to discuss that here.

Regards