### PR TITLE
Create VSCode extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}/src/vscode"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: vscode:watch"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "vscode:watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+      }
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "release:all": "npm run setenv && npm run build:mac && npm run build:win && npm run build:linux",
     "build:mac": "npm run pack:mac && build \"dist/mac/ngrev-darwin-x64/ngrev.app\" --platform=mac",
     "build:win": "npm run pack:win && build \"dist/win/ngrev-win32-ia32\" --platform=win",
-    "build:linux": "npm run pack:linux && build \"dist/win/ngrev-linux-x64\" --platform=linux"
+    "build:linux": "npm run pack:linux && build \"dist/win/ngrev-linux-x64\" --platform=linux",
+    "vscode:prepublish": "npm run compile",
+    "vscode:compile": "tsc -p tsconfig.vscode.json",
+    "vscode:lint": "tslint -p tsconfig.vscode.json",
+    "vscode:watch": "tsc -watch -p tsconfig.vscode.json"
   },
   "dependencies": {
     "@angular/common": "7.0.0-rc.0",
@@ -60,6 +64,7 @@
   "devDependencies": {
     "@types/node": "^7.0.7",
     "@types/sanitize-filename": "^1.1.28",
+    "@types/vscode": "^1.34.0",
     "chai": "^3.5.0",
     "electron": "3.0.2",
     "electron-builder": "^20.28.0",

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+	let disposable = vscode.commands.registerCommand('extension.ngrev', () => {
+		vscode.window.showInformationMessage('Hello ngrev');
+	});
+
+	context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/src/vscode/package.json
+++ b/src/vscode/package.json
@@ -1,0 +1,19 @@
+{
+ "name": "ngrev",
+ "main": "../../out/extension.js",
+ "version": "0.0.1",
+ "engines": {
+  "vscode": "^1.34.0"
+  },
+  "activationEvents": [
+    "onCommand:extension.ngrev"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.ngrev",
+        "title": "Reverse Engineering for Angular"
+      }
+    ]
+  }
+}

--- a/tasks/build_app.js
+++ b/tasks/build_app.js
@@ -26,7 +26,11 @@ gulp.task('bundle', function() {
 var tsProject = ts.createProject('tsconfig.json');
 
 gulp.task('ts', function() {
-  var tsResult = gulp.src('src/**/*.ts').pipe(tsProject());
+  var tsResult = gulp.src([
+                  'src/**/*.ts',
+                  '!src/vscode/*.*'
+                ])
+                .pipe(tsProject());
 
   return tsResult.js.pipe(gulp.dest('dist'));
 });

--- a/tsconfig.vscode.json
+++ b/tsconfig.vscode.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"sourceMap": true,
+		"strict": true,
+		"rootDir": "src/vscode"
+  },
+  "include": [
+    "src/vscode/*.*"
+  ],
+	"exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
Closes #51 

This PR is a WIP attempt to implement **ngrev** as a Visual Studio Code extension.

The first commit contains the proposed folder structure so that the main application and the extension source code are clearly separated:

- I decided to include all **vscode** related scripts in the main `package.json` and create a separate one inside `src/vscode` folder that will contain only extension related artifacts.
- There is also a separate **tsconfig** configuration file for the extension that resides together with the main tsconfig.
- The extension main entry file is emitted in the `out` folder on the root path of the project.

A problem that I noticed is that when running `gulp build`, the extension folder is also compiled and emitted in the `dist` folder. So I think that we need to exclude it from the build process.

Alternatively, we could have extension related scripts in a single `package.json` and `out` folder inside **vscode** directory to keep it more isolated.

@mgechev what do you think?
