### PR TITLE
refactor: IPC observables instead of promises

### DIFF
--- a/src/app/common/ipc.service.ts
+++ b/src/app/common/ipc.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, NgZone } from '@angular/core';
+import { Observable, Subscriber } from 'rxjs';
+import { Message } from '../../shared/ipc-constants';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class IpcService {
+  constructor(private _ngZone: NgZone) {}
+
+  on<T>(event: Message) {
+    const { ipcRenderer } = window.require('electron');
+
+    return new Observable<T>((subscriber: Subscriber<T>) => {
+      const listener = (_: any, data: T) => {
+        this._ngZone.run(() => {
+          subscriber.next(data);
+        });
+      }
+
+      ipcRenderer.addListener(event, listener);
+      return () => {
+        ipcRenderer.removeListener(event, listener);
+      };
+    });
+  }
+}

--- a/src/app/common/ipc.ts
+++ b/src/app/common/ipc.ts
@@ -1,0 +1,51 @@
+import { Observable, Subscriber, throwError } from 'rxjs';
+import { Message, Status } from '../../shared/ipc-constants';
+
+const NonBlocking = {
+  [Message.EnableExport]: true,
+  [Message.DisableExport]: true,
+};
+
+let blocked: boolean = false;
+
+export function isPending(): boolean {
+  return blocked;
+}
+
+export function ipcOn<T>(event: Message): Observable<T> {
+  const { ipcRenderer } = window.require('electron');
+
+  return new Observable<T>((subscriber: Subscriber<T>) => {
+    const listener = (_: any, data: T) => {
+      subscriber.next(data);
+    }
+    ipcRenderer.addListener(event, listener);
+    return () => {
+      ipcRenderer.removeListener(event, listener);
+    };
+  });
+}
+
+export function ipcSend<T, P>(event: Message, payload?: P): Observable<T> {
+  if (isPending() &&  !NonBlocking[event]) {
+    console.log("Trying to send request", event);
+    return throwError('Pending requests');
+  }
+
+  const { ipcRenderer } = window.require('electron');
+  blocked = true;
+  return new Observable<T>((subscriber: Subscriber<T>) => {
+    ipcRenderer.once(event, (e: Message, code: Status, data: T) => {
+      console.log("Got response of type", event);
+      if (code === Status.Success) {
+        subscriber.next(data);
+      } else {
+        subscriber.error(data);
+      }
+      subscriber.complete();
+      blocked = false;
+    });
+
+    ipcRenderer.send(event, payload);
+  });
+}


### PR DESCRIPTION
I'm thinking about refactoring IPCBus to use observables instead of promises;

_ipc.ts_ is more simple and easier to use, but has one disadvantage...It runs outside the angular zone and **detectChanges()** should be called all the time.

_ipc.service.ts_ solution could solve it. So no need to care about running change detection flow. It would be enough **markForCheck()** or use **async** pipe. But this way requires _state-manager.ts_ refactoring as we have **this.state = new StateProxy()**.

I'm gonna refactor it if it's fine for you.