### PR TITLE
fix: metadata issue for modules and components states

### DIFF
--- a/src/electron/states/directive.state.ts
+++ b/src/electron/states/directive.state.ts
@@ -2,7 +2,7 @@ import {
   DirectiveSymbol,
   WorkspaceSymbols,
   ComponentSymbol,
-  InjectableSymbol,
+  InjectableSymbol
 } from 'ngast';
 import { State } from './state';
 import { TmplAstElement } from '@angular/compiler';
@@ -23,7 +23,7 @@ import {
 import { TemplateState } from './template.state';
 
 interface NodeMap {
-  [id: string]: DirectiveSymbol | TmplAstElement;
+  [id: string]: DirectiveSymbol | ComponentSymbol | TmplAstElement;
 }
 
 const TemplateId = 'template';
@@ -46,7 +46,7 @@ export class DirectiveState extends State {
     if (s) {
       if (s instanceof TmplAstElement) {
         return getElementMetadata(s);
-      } else if (s instanceof DirectiveSymbol) {
+      } else if (s instanceof DirectiveSymbol || s instanceof ComponentSymbol) {
         return getDirectiveMetadata(s);
       }
     }

--- a/src/electron/states/module.state.ts
+++ b/src/electron/states/module.state.ts
@@ -13,7 +13,7 @@ import { ComponentSymbol, DirectiveSymbol, InjectableSymbol, NgModuleSymbol, Pip
 import {
   getDirectiveMetadata,
   getProviderMetadata,
-  getPipeMetadata
+  getPipeMetadata, getModuleMetadata
 } from '../formatters/model-formatter';
 import { ProviderState } from './provider.state';
 import { PipeState } from './pipe.state';
@@ -44,12 +44,14 @@ export class ModuleState extends State {
     if (!data) {
       return null;
     }
-    if (data.symbol instanceof DirectiveSymbol) {
+    if (data.symbol instanceof DirectiveSymbol || data.symbol instanceof ComponentSymbol) {
       return getDirectiveMetadata(data.symbol);
     } else if (data.symbol instanceof InjectableSymbol) {
       return getProviderMetadata(data.symbol);
     } else if (data.symbol instanceof PipeSymbol) {
       return getPipeMetadata(data.symbol);
+    } else if (data.symbol instanceof NgModuleSymbol) {
+      return getModuleMetadata(data.symbol);
     }
     return null;
   }


### PR DESCRIPTION
I think for the future it's nice to create separated Component state in order to have different views and prevent using if else.