### PR TITLE
fix: issues with electron menu

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -19,27 +19,32 @@ if (serve) {
   app.setPath('userData', userDataPath + ' (development)');
 }
 
-const onThemeChange = (theme: string) => setConfigProps({ theme });
+const themeChange = (theme: string) => setConfigProps({ theme });
 
-const onAngularToggle = () => {
+const libsToggle = () => {
   const config = getConfig();
   const showLibs = !config.showLibs;
   setConfigProps({ showLibs });
 };
 
-const onModulesToggle = () => {
+const modulesOnlyToggle = () => {
   const config = getConfig();
   const showModules = !config.showModules;
   setConfigProps({ showModules });
 };
 
-const menuItems = [applicationMenuTemplate(onThemeChange, onAngularToggle, onModulesToggle)];
+const menuItems = [
+  applicationMenuTemplate(
+    themeChange,
+    libsToggle,
+    modulesOnlyToggle
+  )
+];
 if (serve) {
   menuItems.push(devMenuTemplate());
 }
 
 export const menus = Menu.buildFromTemplate(menuItems);
-
 
 function createWindow(): BrowserWindow {
   Menu.setApplicationMenu(menus);

--- a/src/electron/config.ts
+++ b/src/electron/config.ts
@@ -14,7 +14,7 @@ const builtInThemesMap = readdirSync(join(__dirname, '..', 'assets'))
     return a;
   }, {});
 
-export const getConfig = () => {
+export const getConfig = (): Config => {
   const path = app.getPath('userData');
   console.log('Looking for config file in', path);
   let config = null;
@@ -24,7 +24,7 @@ export const getConfig = () => {
     console.log('Found config file');
   } catch (_) {
     console.log('Config file not found');
-    return { showLibs: false, showModules: false, theme: DefaultTheme, themes: builtInThemesMap } as Partial<Config>;
+    return { showLibs: false, showModules: false, theme: DefaultTheme, themes: builtInThemesMap };
   }
   try {
     themes = readdirSync(join(path, 'themes'))
@@ -33,9 +33,12 @@ export const getConfig = () => {
     console.log('Found themes');
   } catch (_) {
     console.log('Themes not found', _);
-    return { showLibs: !!(config as any).showLibs, showModules: !!(config as any).showModules, theme: (config as any).theme, themes: builtInThemesMap } as Partial<
-      Config
-    >;
+    return {
+      showLibs: !!(config as any).showLibs,
+      showModules: !!(config as any).showModules,
+      theme: (config as any).theme,
+      themes: builtInThemesMap
+    };
   }
   return {
     showLibs: !!(config as any).showLibs,
@@ -48,7 +51,7 @@ export const getConfig = () => {
       }, {}),
       builtInThemesMap
     )
-  } as Partial<Config>;
+  };
 };
 
 export const setConfigProps = (config: Partial<Config>) => {

--- a/src/electron/menu/application_menu_template.ts
+++ b/src/electron/menu/application_menu_template.ts
@@ -1,12 +1,12 @@
-import { app, BrowserWindow, dialog } from "electron";
+import { app, BrowserWindow, dialog, MenuItem, MenuItemConstructorOptions } from "electron";
 import { Message } from "../../shared/ipc-constants";
 import { getConfig } from "../config";
 
 export const applicationMenuTemplate = (
-  onThemeChange: (name: string) => void,
-  onLibraryToggle: () => void,
-  onModulesToggle: () => void
-) => {
+  themeChange: (name: string) => void,
+  libsToggle: () => void,
+  modulesOnlyToggle: () => void
+): MenuItemConstructorOptions | MenuItem => {
   return {
     label: "ngrev",
     submenu: [
@@ -15,13 +15,40 @@ export const applicationMenuTemplate = (
         submenu: Object.keys(getConfig().themes || []).map((label) => {
           return {
             label,
+            type: "radio",
+            checked: label === getConfig().theme,
             click() {
               const window = BrowserWindow.getAllWindows()[0];
-              onThemeChange(label);
+              themeChange(label);
               window.webContents.send(Message.ChangeTheme, label);
             },
           };
         }),
+      },
+      {
+        label: "Show libs",
+        type: "checkbox",
+        checked: getConfig().showLibs,
+        accelerator: "CmdOrCtrl+L",
+        click() {
+          const window = BrowserWindow.getAllWindows()[0];
+          libsToggle();
+          window.webContents.send(Message.ToggleLibsMenuAction);
+        },
+      },
+      {
+        label: "Show modules only",
+        type: "checkbox",
+        checked: getConfig().showModules,
+        accelerator: "CmdOrCtrl+M",
+        click() {
+          const window = BrowserWindow.getAllWindows()[0];
+          modulesOnlyToggle();
+          window.webContents.send(Message.ToggleModulesMenuAction);
+        },
+      },
+      {
+        type: "separator"
       },
       {
         label: "Export",
@@ -33,22 +60,7 @@ export const applicationMenuTemplate = (
         },
       },
       {
-        label: "Show libs",
-        accelerator: "CmdOrCtrl+L",
-        click() {
-          const window = BrowserWindow.getAllWindows()[0];
-          onLibraryToggle();
-          window.webContents.send(Message.ToggleLibsMenuAction);
-        },
-      },
-      {
-        label: "Show modules only",
-        accelerator: "CmdOrCtrl+M",
-        click() {
-          const window = BrowserWindow.getAllWindows()[0];
-          onModulesToggle();
-          window.webContents.send(Message.ToggleModulesMenuAction);
-        },
+        type: "separator"
       },
       {
         label: "Reset",

--- a/src/electron/menu/dev_menu_template.ts
+++ b/src/electron/menu/dev_menu_template.ts
@@ -1,9 +1,13 @@
-import { app } from 'electron';
+import { app, MenuItem, MenuItemConstructorOptions } from 'electron';
 
-export const devMenuTemplate = () => {
+export const devMenuTemplate = (): MenuItem | MenuItemConstructorOptions => {
   return {
     label: 'Development',
     submenu: [
+      {
+        label: "Reset",
+        role: 'reload'
+      },
       {
         label: 'Quit',
         accelerator: 'CmdOrCtrl+Q',

--- a/src/electron/model/background-app.ts
+++ b/src/electron/model/background-app.ts
@@ -1,14 +1,5 @@
-import {
-  SlaveProcess,
-  LoadProjectResponse,
-  PrevStateResponse,
-  DirectStateTransitionResponse,
-  GetSymbolsResponse,
-  GetMetadataResponse,
-  GetDataResponse,
-  ToggleLibsResponse
-} from '../helpers/process';
-import { ipcMain } from 'electron';
+import { SlaveProcess } from '../helpers/process';
+import { ipcMain, MenuItem } from 'electron';
 import { Message, Status } from '../../shared/ipc-constants';
 import { State } from '../states/state';
 import { Config } from '../../shared/data-format';
@@ -210,12 +201,12 @@ export class BackgroundApp {
     });
 
     ipcMain.on(Message.DisableExport, e => {
-      (menus.items[0] as any).submenu.items[1].enabled = false;
+      (menus.items[0] as MenuItem).submenu.items[4].enabled = false;
       success(e.sender, Message.DisableExport, true);
     });
 
     ipcMain.on(Message.EnableExport, e => {
-      (menus.items[0] as any).submenu.items[1].enabled = true;
+      (menus.items[0] as MenuItem).submenu.items[4].enabled = true;
       console.log('Enable!');
       success(e.sender, Message.EnableExport, true);
     });

--- a/src/electron/parser.ts
+++ b/src/electron/parser.ts
@@ -181,7 +181,7 @@ export class BackgroundApp {
     this.parentProcess.on(Message.ToggleLibs, (_: any, responder: Responder) => {
       console.log('Toggle libraries');
       const state = this.states.shift() as AppState;
-      const newState = new AppState(this.project.projectSymbols, !state.showLibs, !state.showModules);
+      const newState = new AppState(this.project.projectSymbols, !state.showLibs, state.showModules);
       this.states.unshift(newState);
       responder({
         topic: Message.ToggleLibs


### PR DESCRIPTION
- make themes menu as radio, showLibs and moduleOnly items as checkbox;
- fix bug with showModulesOnly. It was switched as well, when showLibs was changed.
- add separators;
