### PR TITLE
feat: remove flickering loading text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="assets/icons/favicon.ico">
 </head>
 <body>
-  <ngrev-app>Loading...</ngrev-app>
+  <ngrev-app></ngrev-app>
 </body>
 </html>


### PR DESCRIPTION
The initial screen and the scripts are relatively small. Users will not see a black screen for long and the flickering "Loading..." text is a suboptimal experience.