### PR TITLE
fix: module's third-party imports

### DIFF
--- a/src/electron/states/module-tree.state.ts
+++ b/src/electron/states/module-tree.state.ts
@@ -89,7 +89,7 @@ export class ModuleTreeState extends State {
   }
 
   private _getModuleGraph(module: NgModuleSymbol): Graph<NgModuleSymbol> {
-    const imports = module.getImports();
+    const imports = module.getImports().filter((m?: NgModuleSymbol) => !!m);
     const nodes: Node<NgModuleSymbol>[] = [
       {
         id: getId(module),


### PR DESCRIPTION
Sometimes I've got undefined inside list of imports **module.getImports()**. Seems it relates to the different version of angular for ngast and loaded project, but it should be investigated more.