### PR TITLE
fix: run change detection when settings are changed

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -81,11 +81,13 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     this._ipcBus.on(Message.ToggleLibsMenuAction, () => {
       this.manager.toggleLibs().then(() => {
         this.manager.reloadAppState();
+        this._cd.detectChanges();
       });
     });
     this._ipcBus.on(Message.ToggleModulesMenuAction, () => {
       this.manager.toggleModules().then(() => {
         this.manager.reloadAppState();
+        this._cd.detectChanges();
       });
     });
   }
@@ -142,7 +144,9 @@ the Angular's AoT compiler. Error during parsing:\n\n${formatError(error)}`
   }
 
   get initialized(): VisualizationConfig<any> | null {
-    return this.manager.getCurrentState();
+    return this.manager.getCurrentState(() => {
+      this._cd.detectChanges();
+    });
   }
 
   prevState(): void {


### PR DESCRIPTION
This is quick fix. I would like to refactor this part as currently **get initialized()** is called at least 4 times on every tick.